### PR TITLE
Prefix and cleanup arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ To run the tests:
     # If you set it in the tests will run against a real google storage bucket.
     # See https://developers.google.com/identity/protocols/application-default-credentials#howtheywork;
     # you need to get Application Default Credentials before writing to your bucket.
-    KUBEFACE_BUCKET=kubeface-test  # tests will write to gs://kubeface-test.
+    KUBEFACE_STORAGE=gs://kubeface-test  # tests will write to gs://kubeface-test.
 
     # Run tests:
     nosetests
@@ -109,12 +109,11 @@ Now launch a command:
     kubeface-run \
         --expression 'value**2' \
         --generator-expression 'range(10)' \
-        --max-simultaneous-tasks 10 \
-        --backend kubernetes \
-        --storage-prefix "gs://$KUBEFACE_BUCKET" \
-        --worker-image continuumio/anaconda3 \
-        --kubernetes-task-resources-cpu 1 \
-        --kubernetes-task-resources-memory-mb 500 \
+        --kubeface-max-simultaneous-tasks 10 \
+        --kubeface-backend kubernetes \
+        --kubeface-worker-image continuumio/anaconda3 \
+        --kubeface-kubernetes-task-resources-cpu 1 \
+        --kubeface-kubernetes-task-resources-memory-mb 500 \
         --verbose \
         --out-csv /tmp/result.csv
 

--- a/broadcast_example.py
+++ b/broadcast_example.py
@@ -1,12 +1,14 @@
 """
 Kubeface example with broadcast variables.
 
-Prepends numbers 1-3 to a big string, showing how to use broadcast variables to reduce the
-size of the uploaded task.
+Prepends numbers 1-3 to a big string, showing how to use broadcast
+variables to reduce the size of the uploaded task.
 
 Example:
 
-$ python broadcast_example.py --backend local-process --storage-prefix /tmp
+$ python broadcast_example.py \
+    --kubeface-backend local-process \
+    --kubeface-storage /tmp
 
 """
 
@@ -22,33 +24,37 @@ kubeface.Client.add_args(parser)  # Add kubeface arguments
 
 
 def main(argv):
-	args = parser.parse_args(argv)
-	logging.basicConfig(
+    args = parser.parse_args(argv)
+    logging.basicConfig(
         format="%(asctime)s.%(msecs)d %(levelname)s %(module)s - %(funcName)s:"
         " %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
         stream=sys.stderr,
         level=logging.INFO)
 
-	client = kubeface.Client.from_args(args)
-	input_values = range(3)
+    client = kubeface.Client.from_args(args)
+    input_values = range(3)
 
-	big_string = "i am a string" * 100000
-	big_wrapped = client.broadcast(big_string)
+    big_string = "i am a string" * 100000
+    big_wrapped = client.broadcast(big_string)
 
-	logging.info('Using broadcast variable: note size of uploaded task')
-	def my_func_with_broadcast(x):
-		return str(x) + big_wrapped.data
-	results = client.map(my_func_with_broadcast, input_values)
-	for (x, result) in zip(input_values, results):
-		print("%d, %s" % (x, Counter(result)))
+    logging.info('Using broadcast variable: note size of uploaded task')
 
-	logging.info('Now running without broadcast variable: see uploaded task size again')
-	def my_func_without_broadcast(x):
-		return str(x) + big_string
-	results = client.map(my_func_without_broadcast, input_values)
-	for (x, result) in zip(input_values, results):
-		print("%d, %s" % (x, Counter(result)))
+    def my_func_with_broadcast(x):
+        return str(x) + big_wrapped.data
+    results = client.map(my_func_with_broadcast, input_values)
+    for (x, result) in zip(input_values, results):
+        print("%d, %s" % (x, Counter(result)))
+
+    logging.info(
+        'Now running without broadcast: see uploaded task size')
+
+    def my_func_without_broadcast(x):
+        return str(x) + big_string
+
+    results = client.map(my_func_without_broadcast, input_values)
+    for (x, result) in zip(input_values, results):
+        print("%d, %s" % (x, Counter(result)))
 
 
 if __name__ == '__main__':

--- a/example.py
+++ b/example.py
@@ -5,7 +5,7 @@ Computes the square of numbers 1 .. N, where N is specified on the commandline.
 
 Example:
 
-$ python example.py 10 --backend local-process --storage-prefix /tmp
+$ python example.py 10 --kubeface-backend local-process --kubeface-storage /tmp
 
 """
 
@@ -18,6 +18,7 @@ parser = argparse.ArgumentParser(usage=__doc__)
 parser.add_argument("n", type=int)
 kubeface.Client.add_args(parser)  # Add kubeface arguments
 
+
 def my_function(x):
     return x**2
 
@@ -27,7 +28,7 @@ def main(argv):
     client = kubeface.Client.from_args(args)
 
     input_values = range(1, args.n + 1)
-    results = client.map(my_function, input_values) 
+    results = client.map(my_function, input_values)
 
     for (x, result) in zip(input_values, results):
         print("%5d**2 = %5d" % (x, result))

--- a/kubeface/backend.py
+++ b/kubeface/backend.py
@@ -2,5 +2,5 @@ class Backend(object):
     def submit_task(self, task_input, task_output):
         raise NotImplementedError
 
-    def supports_storage_prefix(self, storage_prefix):
+    def supports_storage(self, path_or_url):
         return True

--- a/kubeface/backends.py
+++ b/kubeface/backends.py
@@ -13,7 +13,7 @@ BACKENDS = collections.OrderedDict([
 
 def add_args(parser):
     parser.add_argument(
-        "--backend",
+        "--kubeface-backend",
         choices=tuple(BACKENDS),
         default=tuple(BACKENDS)[0])
 
@@ -23,4 +23,4 @@ def add_args(parser):
 
 
 def backend_from_args(args):
-    return BACKENDS[args.backend].from_args(args)
+    return BACKENDS[args.kubeface_backend].from_args(args)

--- a/kubeface/commands/run_task.py
+++ b/kubeface/commands/run_task.py
@@ -7,6 +7,9 @@ import argparse
 import logging
 import tempfile
 import math
+import signal
+import traceback
+import os
 
 from .. import storage, serialization
 from ..common import configure_logging
@@ -37,6 +40,11 @@ parser.add_argument(
 
 def run(argv=sys.argv[1:]):
     args = parser.parse_args(argv)
+
+    # On sigusr1 print stack trace
+    print("To show stack trace, run:\nkill -s USR1 %d" % os.getpid())
+    signal.signal(signal.SIGUSR1, lambda sig, frame: traceback.print_stack())
+
     configure_logging(args)
 
     logging.info("Reading: %s" % args.input_path)

--- a/kubeface/job.py
+++ b/kubeface/job.py
@@ -18,7 +18,7 @@ class Job(object):
             backend,
             tasks_iter,
             max_simultaneous_tasks,
-            storage_prefix,
+            storage,
             cache_key,
             num_tasks=None,
             wait_to_raise_task_exception=False,
@@ -29,7 +29,7 @@ class Job(object):
         self.backend = backend
         self.tasks_iter = tasks_iter
         self.max_simultaneous_tasks = max_simultaneous_tasks
-        self.storage_prefix = storage_prefix
+        self.storage = storage
         self.cache_key = cache_key
         self.num_tasks = num_tasks
         self.wait_to_raise_task_exception = wait_to_raise_task_exception
@@ -43,7 +43,7 @@ class Job(object):
         self.reused_tasks = set()
         self.completed_tasks = {}
         self.running_tasks = set()
-        self.status_writer = DefaultStatusWriter(storage_prefix, self.job_name)
+        self.status_writer = DefaultStatusWriter(storage, self.job_name)
 
         self.status_writer.print_info()
 
@@ -65,7 +65,7 @@ class Job(object):
         return result
 
     def storage_path(self, filename):
-        return self.storage_prefix + "/" + filename
+        return self.storage + "/" + filename
 
     def submit_task(self, task_name):
         queue_time = int(time.time())

--- a/kubeface/kubernetes_backend.py
+++ b/kubeface/kubernetes_backend.py
@@ -17,33 +17,33 @@ class KubernetesBackend(Backend):
     def add_args(parser):
         default = KubernetesBackend(worker_configuration=None)
         parser.add_argument(
-            "--kubernetes-cluster",
+            "--kubeface-kubernetes-cluster",
             default=default.cluster,
             help="Cluster. Default: %(default)s")
         parser.add_argument(
-            "--kubernetes-task-resources-cpu",
+            "--kubeface-kubernetes-task-resources-cpu",
             default=default.task_resources_cpu,
             type=int,
             help="CPUs per task. Default: %(default)s")
         parser.add_argument(
-            "--kubernetes-task-resources-memory-mb",
+            "--kubeface-kubernetes-task-resources-memory-mb",
             default=default.task_resources_memory_mb,
             type=float,
             help="Memory (mb) per task. Default: %(default)s")
         parser.add_argument(
-            "--kubernetes-retries",
+            "--kubeface-kubernetes-retries",
             default=default.retries,
             type=int,
             help="Max retries for kubernetes commands. Default: %(default)s")
         parser.add_argument(
-            "--kubernetes-image-pull-policy",
+            "--kubeface-kubernetes-image-pull-policy",
             default=default.image_pull_policy,
             choices=("Always", "IfNotPresent", "Never"),
             help="Image pull policy. Default: %(default)s")
 
     @staticmethod
     def from_args(args):
-        arg_prefix = "kubernetes_"
+        arg_prefix = "kubeface_kubernetes_"
         return KubernetesBackend(
             worker_configuration=WorkerConfiguration.from_args(args),
             **dict(
@@ -142,6 +142,6 @@ class KubernetesBackend(Backend):
         return result
 
     @staticmethod
-    def supports_storage_prefix(storage_prefix):
+    def supports_storage(path):
         # kubernetes backend requires bucket storage
-        return is_google_storage_bucket(storage_prefix)
+        return is_google_storage_bucket(path)

--- a/kubeface/local_process_docker_backend.py
+++ b/kubeface/local_process_docker_backend.py
@@ -18,14 +18,14 @@ class LocalProcessDockerBackend(Backend):
     @staticmethod
     def add_args(parser):
         parser.add_argument(
-            "--local-process-docker-command",
+            "--kubeface-local-process-docker-command",
             default="docker")
 
     @staticmethod
     def from_args(args):
         return LocalProcessDockerBackend(
             worker_configuration=WorkerConfiguration.from_args(args),
-            docker_command=args.local_process_docker_command)
+            docker_command=args.kubeface_local_process_docker_command)
 
     def __init__(
             self,

--- a/kubeface/status_writer.py
+++ b/kubeface/status_writer.py
@@ -6,18 +6,18 @@ from . import naming, storage
 
 
 class DefaultStatusWriter(object):
-    def __init__(self, storage_prefix, job_name):
-        self.storage_prefix = storage_prefix
+    def __init__(self, storage_path, job_name):
+        self.storage_path = storage_path
         self.job_name = job_name
         self.json_path = (
-            storage_prefix +
+            storage_path +
             "/" +
             naming.JOB_STATUS_PAGE.make_string(
                 job_name=job_name,
                 format="json",
                 status="active"))
         self.html_path = (
-            storage_prefix +
+            storage_path +
             "/" +
             naming.JOB_STATUS_PAGE.make_string(
                 job_name=job_name,

--- a/kubeface/worker_configuration.py
+++ b/kubeface/worker_configuration.py
@@ -2,27 +2,28 @@ import os
 
 from six.moves import shlex_quote as quote
 
+
 class WorkerConfiguration(object):
     @staticmethod
     def add_args(parser):
         parser.add_argument(
-            "--worker-image",
+            "--kubeface-worker-image",
             default=DEFAULT.image)
         parser.add_argument(
-            "--worker-path-prefix",
+            "--kubeface-worker-path-prefix",
             default=DEFAULT.path_prefix)
         parser.add_argument(
-            "--worker-pip",
+            "--kubeface-worker-pip",
             default=DEFAULT.pip)
         parser.add_argument(
-            "--worker-pip-packages",
+            "--kubeface-worker-pip-packages",
             default=DEFAULT.pip_packages)
         parser.add_argument(
-            "--worker-kubeface-install-policy",
+            "--kubeface-worker-kubeface-install-policy",
             choices=('if-not-present', 'always', 'never'),
             default=DEFAULT.kubeface_install_policy)
         parser.add_argument(
-            "--worker-kubeface-install-command",
+            "--kubeface-worker-kubeface-install-command",
             default=DEFAULT.kubeface_install_command)
 
     @staticmethod

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -38,7 +38,7 @@ def test_local_process_backend(bucket):
         backend,
         poll_seconds=1.0,
         max_simultaneous_tasks=3,
-        storage_prefix=bucket)
+        storage=bucket)
     exercise_client(c)
 
 
@@ -52,17 +52,17 @@ def test_local_process_docker_backend(bucket):
         backend,
         poll_seconds=1.0,
         max_simultaneous_tasks=1,
-        storage_prefix=bucket)
+        storage=bucket)
     exercise_client(c, high=3)
 
 
 @util.with_local_and_bucket_storage
 def test_worker_exception_delayed(bucket):
     c = client_from_commandline_args([
-        "--poll-seconds", "1.1",
-        "--backend", "local-process",
-        "--storage-prefix", bucket,
-        "--wait-to-raise-task-exception",
+        "--kubeface-poll-seconds", "1.1",
+        "--kubeface-backend", "local-process",
+        "--kubeface-storage", bucket,
+        "--kubeface-wait-to-raise-task-exception",
     ])
     mapper = c.map(lambda x: 2 / (x - 2), range(10))
     testing.assert_equal(next(mapper), -1)
@@ -80,9 +80,9 @@ def test_worker_exception_delayed(bucket):
 @util.with_local_and_bucket_storage
 def test_worker_exception(bucket):
     c = client_from_commandline_args([
-        "--poll-seconds", "1.1",
-        "--backend", "local-process",
-        "--storage-prefix", bucket,
+        "--kubeface-poll-seconds", "1.1",
+        "--kubeface-backend", "local-process",
+        "--kubeface-storage", bucket,
     ])
     mapper = c.map(lambda x: 2 / (x - 2), range(10))
     testing.assert_raises(ZeroDivisionError, next, mapper)
@@ -91,9 +91,9 @@ def test_worker_exception(bucket):
 @util.with_local_and_bucket_storage
 def test_job_summary(bucket):
     c = client_from_commandline_args([
-        "--poll-seconds", "1.1",
-        "--backend", "local-process",
-        "--storage-prefix", bucket,
+        "--kubeface-poll-seconds", "1.1",
+        "--kubeface-backend", "local-process",
+        "--kubeface-storage", bucket,
     ])
 
     exercise_client(c, high=5)
@@ -119,18 +119,18 @@ def test_job_summary(bucket):
 def test_invalid_client():
     with testing.assert_raises(ValueError):
         client_from_commandline_args([
-            "--poll-seconds", "1.1",
-            "--backend", "kubernetes",
-            "--storage-prefix", "/tmp",
+            "--kubeface-poll-seconds", "1.1",
+            "--kubeface-backend", "kubernetes",
+            "--kubeface-storage", "/tmp",
         ])
 
 
 @util.with_local_and_bucket_storage
 def test_broadcast(bucket):
     c = client_from_commandline_args([
-        "--poll-seconds", "1.1",
-        "--backend", "local-process",
-        "--storage-prefix", bucket,
+        "--kubeface-poll-seconds", "1.1",
+        "--kubeface-backend", "local-process",
+        "--kubeface-storage", bucket,
     ])
     data = numpy.arange(10000)**2
     serialized_data = serialization.dumps(data)

--- a/tests/test_job_command.py
+++ b/tests/test_job_command.py
@@ -1,5 +1,4 @@
 import math
-import numpy
 import argparse
 import subprocess
 from numpy import testing
@@ -22,7 +21,7 @@ def client_from_commandline_args(argv):
 
 def run_job_command(bucket, argv):
     result = subprocess.check_output(
-        ["kubeface-job", "--storage-prefix", bucket] + argv).decode()
+        ["kubeface-job", "--kubeface-storage", bucket] + argv).decode()
     print(result)
     return result
 
@@ -36,9 +35,9 @@ def find_line_with(needle, haystack, nth=0):
 @util.with_local_storage
 def test_job_command(bucket):
     c = client_from_commandline_args([
-        "--poll-seconds", "1.1",
-        "--backend", "local-process",
-        "--storage-prefix", bucket,
+        "--kubeface-poll-seconds", "1.1",
+        "--kubeface-backend", "local-process",
+        "--kubeface-storage", bucket,
     ])
 
     mapper = c.map(math.exp, range(10), cache_key='FOOBARBAZ')

--- a/tests/util.py
+++ b/tests/util.py
@@ -24,7 +24,7 @@ def check_empty(bucket_url):
 
 
 def with_bucket_storage(function):
-    bucket = os.environ.get("KUBEFACE_BUCKET")
+    bucket = os.environ.get("KUBEFACE_STORAGE")
     if not bucket:
         logging.fatal("No bucket defined")
 
@@ -46,10 +46,10 @@ def with_local_storage(function):
 
 
 def with_local_and_bucket_storage(function):
-    bucket = os.environ.get("KUBEFACE_BUCKET")
+    bucket = os.environ.get("KUBEFACE_STORAGE")
     if not bucket:
         logging.warning(
-            "Set KUBEFACE_BUCKET to run test: %s" % str(function))
+            "Set KUBEFACE_STORAGE to run test: %s" % str(function))
         return with_local_storage(function)
 
     def test_function():


### PR DESCRIPTION
 * Prefix all kubeface arguments with `--kubeface`. Closes #33
 * Rename `--storage-prefix` argument to `--kubeface-storage`. Closes #35
 * Task running now prints a stack trace when sent SIGUSR1
 * Fix formatting in example scripts
 * Rename KUBEFACE_BUCKET to KUBEFACE_STORAGE environment variable. You must now include the 'gs://' when setting KUBEFACE_STORAGE.