### PR TITLE
Allow tasks to return remote objects

### DIFF
--- a/kubeface/commands/run_task.py
+++ b/kubeface/commands/run_task.py
@@ -13,6 +13,7 @@ import os
 
 from .. import storage, serialization
 from ..common import configure_logging
+from ..context import RUNTIME_CONTEXT
 
 parser = argparse.ArgumentParser(description=__doc__)
 
@@ -46,6 +47,10 @@ def run(argv=sys.argv[1:]):
     signal.signal(signal.SIGUSR1, lambda sig, frame: traceback.print_stack())
 
     configure_logging(args)
+
+    RUNTIME_CONTEXT["node_type"] = "task"
+    RUNTIME_CONTEXT["task_input_path"] = args.input_path
+    RUNTIME_CONTEXT["task_result_path"] = args.result_path
 
     logging.info("Reading: %s" % args.input_path)
     input_handle = storage.get(args.input_path)

--- a/kubeface/context.py
+++ b/kubeface/context.py
@@ -1,0 +1,24 @@
+"""
+This module defines information that allows code to determine if it is running
+on a master Kubeface node (node_type == "master") or as a task
+(node_type == "task").
+
+This dict defaults to indicating running on a master node, and is updated by
+the run-task command with task-specific information.
+"""
+
+from .naming import hash_value
+
+RUNTIME_CONTEXT = {
+    "node_type": "master",
+    "task_input_path": None,
+    "task_result_path": None,
+}
+
+
+def node_id():
+    if RUNTIME_CONTEXT["node_type"] == "master":
+        return "node-master"
+    return "node-%s" % (
+        hash_value(
+            RUNTIME_CONTEXT["task_result_path"]))

--- a/kubeface/job.py
+++ b/kubeface/job.py
@@ -6,7 +6,7 @@ import collections
 from numpy import percentile, mean
 
 from .serialization import dump
-from . import storage, naming
+from . import storage, naming, context
 from .status_writer import DefaultStatusWriter
 from .common import human_readable_memory_size
 from .result import Result
@@ -37,7 +37,8 @@ class Job(object):
         self.speculation_runtime_percentile = speculation_runtime_percentile
         self.speculation_max_reruns = speculation_max_reruns
 
-        self.job_name = naming.make_job_name(self.cache_key)
+        self.job_name = naming.make_job_name(
+            self.cache_key, node_id=context.node_id())
         self.task_queue_times = collections.defaultdict(list)
         self.submitted_tasks = []
         self.reused_tasks = set()
@@ -225,7 +226,7 @@ class Job(object):
                                 elapsed_times,
                                 self.speculation_runtime_percentile)
                             logging.info(
-                                "Enabling speculation: %0.2ff%% of tasks "
+                                "Enabling speculation: %0.2f%% of tasks "
                                 "running. "
                                 "Task queue times (sec): "
                                 "min=%0.1f mean=%0.1f max=%0.1f. Queue time "

--- a/kubeface/naming.py
+++ b/kubeface/naming.py
@@ -8,7 +8,7 @@ from .stringable import Stringable
 
 JOB = Stringable(
     "Job",
-    "{cache_key}::{randomness}")
+    "{cache_key}::{node_id}::{randomness}")
 
 TASK = Stringable(
     "Task",
@@ -34,9 +34,9 @@ JOB_STATUS_PAGE = Stringable(
         'status': ['active', 'done'],
     })
 
-BROADCAST = Stringable(
-    "Broadcast",
-    "broadcast::{cache_key_prefix}::{broadcast_num:d}-{randomness}")
+REMOTE_OBJECT = Stringable(
+    "RemoteObject",
+    "object::{cache_key_prefix}::{node_id}::{object_num:d}-{randomness}")
 
 
 def hash_value(s, characters=8):
@@ -52,16 +52,18 @@ def make_cache_key_prefix():
     return cache_key_prefix
 
 
-def make_job_name(cache_key):
+def make_job_name(cache_key, node_id):
     return JOB.make_string(
         cache_key=cache_key,
+        node_id=node_id,
         randomness=hash_value(time.time()))
 
 
-def make_broadcast_name(cache_key_prefix, broadcast_num):
-    return BROADCAST.make_string(
+def make_remote_object_name(cache_key_prefix, node_id, object_num):
+    return REMOTE_OBJECT.make_string(
         cache_key_prefix=cache_key_prefix,
-        broadcast_num=broadcast_num,
+        node_id=node_id,
+        object_num=object_num,
         randomness=hash_value(time.time()))
 
 

--- a/kubeface/remote_object.py
+++ b/kubeface/remote_object.py
@@ -5,22 +5,34 @@ from contextlib import closing
 from . import common, serialization, storage
 
 
-class Broadcast(object):
-
+class RemoteObject(object):
     def __init__(self, file_path, value):
         self.file_path = file_path
-        self.value = value
+        self._value = value
         self.written = False
+        self.loaded = True
+
+    @property
+    def value(self):
+        """
+        Value is lazy loaded when it is first accessed.
+        """
+        if not self.loaded:
+            with closing(storage.get(self.file_path)) as fd:
+                self._value = serialization.load(fd)
+            self.loaded = True
+        return self._value
 
     def __getstate__(self):
         """
-        The first time the Broadcast is pickled, we write it to file_path.
+        The first time the object is pickled, we write it to file_path.
         The pickled representation is just the path to the file.
         """
         if not self.written:
-            with tempfile.TemporaryFile(prefix="kubeface-broadcast-") as fd:
-                serialization.dump(self.value, fd)
-                logging.info("Writing broadcast (%s): %s" % (
+            assert self.loaded
+            with tempfile.TemporaryFile(prefix="kubeface-object-") as fd:
+                serialization.dump(self._value, fd)
+                logging.info("Writing object (%s): %s" % (
                     common.human_readable_memory_size(fd.tell()),
                     self.file_path))
                 fd.seek(0)
@@ -31,6 +43,6 @@ class Broadcast(object):
     def __setstate__(self, state):
         assert list(state) == ['file_path']
         self.file_path = state['file_path']
-        with closing(storage.get(state['file_path'])) as fd:
-            self.value = serialization.load(fd)
+        self._value = None
         self.written = True
+        self.loaded = False

--- a/remote_object_example.py
+++ b/remote_object_example.py
@@ -1,12 +1,12 @@
 """
-Kubeface example with broadcast variables.
+Kubeface example with remote objects.
 
-Prepends numbers 1-3 to a big string, showing how to use broadcast
-variables to reduce the size of the uploaded task.
+Prepends numbers 1-3 to a big string, showing how to use remote objects to
+reduce the size of the uploaded task.
 
 Example:
 
-$ python broadcast_example.py \
+$ python remote_object_example.py \
     --kubeface-backend local-process \
     --kubeface-storage /tmp
 
@@ -36,23 +36,23 @@ def main(argv):
     input_values = range(3)
 
     big_string = "i am a string" * 100000
-    big_wrapped = client.broadcast(big_string)
+    big_wrapped = client.remote_object(big_string)
 
-    logging.info('Using broadcast variable: note size of uploaded task')
+    logging.info('Using remote object: note size of uploaded task')
 
-    def my_func_with_broadcast(x):
+    def my_func_with_remote_object(x):
         return str(x) + big_wrapped.data
-    results = client.map(my_func_with_broadcast, input_values)
+    results = client.map(my_func_with_remote_object, input_values)
     for (x, result) in zip(input_values, results):
         print("%d, %s" % (x, Counter(result)))
 
     logging.info(
-        'Now running without broadcast: see uploaded task size')
+        'Now running without remote object: see uploaded task size')
 
-    def my_func_without_broadcast(x):
+    def my_func_without_remote_object(x):
         return str(x) + big_string
 
-    results = client.map(my_func_without_broadcast, input_values)
+    results = client.map(my_func_without_remote_object, input_values)
     for (x, result) in zip(input_values, results):
         print("%d, %s" % (x, Counter(result)))
 

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -4,7 +4,8 @@ from kubeface import naming
 
 
 def test_basics():
-    job = naming.JOB.make_string(cache_key="foo", randomness="123")
+    job = naming.JOB.make_string(
+        cache_key="foo", node_id="node-master", randomness="123")
     print(job)
     testing.assert_equal(
         naming.JOB.make_string(naming.JOB.make_tuple(job)),


### PR DESCRIPTION
 * Rename Broadcast to RemoteObject
 * Add context module to allow code to discover if it's running as a task or in the master process
 * Add a node_id field to Job names and remote object names so jobs / objects created by tasks remain unique
 * Make Client pickleable
 * Turn on speculation by default.

Closes #42